### PR TITLE
release/0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`
 - Removed `Module` metadata requirements
+- Fixed an issue where MongoTask would not sort consistently
 
 ## 0.8.0
 - [#30](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/30) - Added the `EnqueueTask` which allows for the queuing of subtasks via the Api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`
+- Removed `Module` metadata requirements
 
 ## 0.8.0
 - [#30](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/30) - Added the `EnqueueTask` which allows for the queuing of subtasks via the Api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#37](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/37): Log messages now include the calling filename, line number, and task name. 
 - [#38](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/38): Address `'NoneType' object has no attriute 'append'` in the `TaskError` exception class.
  - `BaseTask` now offers the `prefix` property used for log entries.
+- `HarvestUpdateTask.bulk_replace()` now chunks large replacements to prevent overwhelming the database.
 
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.2
+- [#36](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/36): `MongoTask` and `RedisTask` will now retry database operations using a new method provided in `BaseDataTask`.
+- `BaseTask` now offers the `prefix` property used for log entries.
+
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`
 - Removed `Module` metadata requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#38](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/38): Address `'NoneType' object has no attriute 'append'` in the `TaskError` exception class.
  - `BaseTask` now offers the `prefix` property used for log entries.
 - `HarvestUpdateTask.bulk_replace()` now chunks large replacements to prevent overwhelming the database.
+- Added `filter_datetime_ago()` jinja2 filter.
 
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.8.2
 - [#36](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/36): `MongoTask` and `RedisTask` will now retry database operations using a new method provided in `BaseDataTask`.
+- [#37](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/37): Log messages now include the calling filename, line number, and task name. 
 - [#38](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/38): Address `'NoneType' object has no attriute 'append'` in the `TaskError` exception class.
-- Log messages now include the calling filename and line number.
  - `BaseTask` now offers the `prefix` property used for log entries.
 
 ## 0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - now chunks large replacements to prevent overwhelming the database.
   - now retries writes as sometimes the backend database is too busy to complete the request at that time.
 - Added `filter_datetime_ago()` jinja2 filter.
+- `BaseFilterableTask` now includes `add_hidden_fields` which returns certain key fields back to the client.
 
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - [#37](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/37): Log messages now include the calling filename, line number, and task name. 
 - [#38](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/38): Address `'NoneType' object has no attriute 'append'` in the `TaskError` exception class.
  - `BaseTask` now offers the `prefix` property used for log entries.
-- `HarvestUpdateTask.bulk_replace()` now chunks large replacements to prevent overwhelming the database.
+- `HarvestUpdateTask.bulk_replace()`
+  - now chunks large replacements to prevent overwhelming the database.
+  - now retries writes as sometimes the backend database is too busy to complete the request at that time.
 - Added `filter_datetime_ago()` jinja2 filter.
 
 ## 0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.8.2
 - [#36](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/36): `MongoTask` and `RedisTask` will now retry database operations using a new method provided in `BaseDataTask`.
-- `BaseTask` now offers the `prefix` property used for log entries.
+- [#38](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/38): Address `'NoneType' object has no attriute 'append'` in the `TaskError` exception class.
 - Log messages now include the calling filename and line number.
+ - `BaseTask` now offers the `prefix` property used for log entries.
 
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.2
 - [#36](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/36): `MongoTask` and `RedisTask` will now retry database operations using a new method provided in `BaseDataTask`.
 - `BaseTask` now offers the `prefix` property used for log entries.
+- Log messages now include the calling filename and line number.
 
 ## 0.8.1
 - Removed `meta.json` in favor of using `pyproject.toml`

--- a/CloudHarvestCoreTasks/dataset.py
+++ b/CloudHarvestCoreTasks/dataset.py
@@ -661,7 +661,7 @@ class DataSet(List[WalkableDict]):
 
         target_key = target_key or source_key
 
-        from json import loads, JSONDecodeError
+        from json import loads
 
         for record in self:
             # Get the value from the source key
@@ -670,7 +670,7 @@ class DataSet(List[WalkableDict]):
             try:
                 source_value = loads(source_value)
 
-            except JSONDecodeError:
+            except Exception:
                 # Don't take any action if the value is not a valid JSON string
                 pass
 

--- a/CloudHarvestCoreTasks/exceptions.py
+++ b/CloudHarvestCoreTasks/exceptions.py
@@ -16,11 +16,16 @@ class BaseHarvestException(BaseException):
         stack = traceback.extract_stack()
         if len(stack) >= 3:
             filename, lineno, _, _ = stack[-3]
+
+            # Only keep the filename and the last directory
+            from os import sep
+            filename = filename.split(sep)[-2:]
+
         else:
             filename, lineno = '<unknown>', 0
 
         message = format_args(*args)
-        log_message = f'{prefix}({filename}:{lineno}) {message}'
+        log_message = f'{prefix}: ({filename}:{lineno}) {message}'
 
         getattr(logger, log_level.lower())(log_message)
 

--- a/CloudHarvestCoreTasks/exceptions.py
+++ b/CloudHarvestCoreTasks/exceptions.py
@@ -34,13 +34,6 @@ class TaskError(BaseHarvestException):
         # Format the arguments into something human-readable by recursively joining them into a string.
         formatted_args = format_args(*args)
 
-        # Configure the log prefix
-        if task.task_chain:
-            prefix = f'{task.task_chain.redis_name}[{task.task_chain.position + 1}]'
-
-        else:
-            prefix = task.name
-
         # Make sure the BaseTask.errors is a list (instantiated as None)
         if not isinstance(task.errors, list):
             task.errors = []
@@ -51,7 +44,7 @@ class TaskError(BaseHarvestException):
         from CloudHarvestCoreTasks.tasks import TaskStatusCodes
         task.status = TaskStatusCodes.error
 
-        super().__init__(prefix, formatted_args, **kwargs)
+        super().__init__(task.prefix, formatted_args, **kwargs)
 
 
 class TaskTerminationError(TaskError):

--- a/CloudHarvestCoreTasks/exceptions.py
+++ b/CloudHarvestCoreTasks/exceptions.py
@@ -12,8 +12,17 @@ class BaseHarvestException(BaseException):
     """
 
     def __init__(self, prefix: str, *args, log_level: _log_levels = 'error', **kwargs):
+        import traceback
+        stack = traceback.extract_stack()
+        if len(stack) >= 3:
+            filename, lineno, _, _ = stack[-3]
+        else:
+            filename, lineno = '<unknown>', 0
+
         message = format_args(*args)
-        getattr(logger, log_level.lower())(f'{prefix}: {message}')
+        log_message = f'{prefix}({filename}:{lineno}) {message}'
+
+        getattr(logger, log_level.lower())(log_message)
 
         super().__init__(message)
 

--- a/CloudHarvestCoreTasks/exceptions.py
+++ b/CloudHarvestCoreTasks/exceptions.py
@@ -19,7 +19,7 @@ class BaseHarvestException(BaseException):
 
             # Only keep the filename and the last directory
             from os import sep
-            filename = filename.split(sep)[-2:]
+            filename = sep.join(filename.split(sep)[-2:])
 
         else:
             filename, lineno = '<unknown>', 0

--- a/CloudHarvestCoreTasks/pyproject.toml
+++ b/CloudHarvestCoreTasks/pyproject.toml
@@ -37,7 +37,7 @@ description = "This module is a core component of CloudHarvest, providing essent
 name = "CloudHarvestCoreTasks"
 readme = "README.md"
 requires-python = ">=3.13"
-version = "0.8.1"
+version = "0.8.2"
 
 [project.license]
 file = "LICENSE"

--- a/CloudHarvestCoreTasks/tasks/base.py
+++ b/CloudHarvestCoreTasks/tasks/base.py
@@ -172,6 +172,27 @@ class BaseTask:
         except ValueError:
             return -1
 
+    @property
+    def prefix(self) -> str:
+        """
+        Returns a string for log prefixing.
+        """
+
+        redis_name, task_index, task_name = (
+            self.task_chain.redis_name if self.task_chain is not None else None,
+            self.task_chain.index(self) + 1 if self.task_chain is not None else None,
+            self.name
+        )
+
+        # If the 'redis_name' property exists, then the 'task_index' should be determinable.
+        if redis_name and task_index:
+            return f'{redis_name}[{task_index}].{task_name}'
+
+        # This would occur if the task is not part of a task chain which is possible, though typically only
+        # in testing scenarios.
+        else:
+            return task_name
+
     def apply_filters(self) -> 'BaseTask':
         """
         Applies user filters to the Task. The default user filter class is HarvestRecordSetUserFilter which is executed
@@ -503,6 +524,8 @@ class BaseDataTask(BaseTask):
                  silo: str,
                  command: str = None,
                  arguments: dict = None,
+                 query_retry_max_attempts: int = 3,
+                 query_retry_delay_seconds: float = 1.0,
                  *args, **kwargs):
         """
         Initializes a new instance of the BaseDataTask class. In order to instantiate a BaseDataTask, a configuration
@@ -517,6 +540,8 @@ class BaseDataTask(BaseTask):
             silo (str, optional): The name of the silo to use for the task. Defaults to None.
             command (str, optional): The command to run on the data provider. Defaults to None. Subclasses should implement a default command.
             arguments (dict, optional): Arguments to pass to the command.
+            query_retry_max_attempts (int, optional): The maximum number of attempts to retry a query. Defaults to 3.
+            query_retry_delay_seconds (float, optional): The number of seconds to wait before retrying a query. Defaults to 1.0.
         """
 
         # Initialize the BaseTask class
@@ -528,6 +553,8 @@ class BaseDataTask(BaseTask):
         self.silo = get_silo(silo)
         self.arguments = arguments or {}
         self.command = command
+        self.query_retry_max_attempts = query_retry_max_attempts or 3
+        self.query_retry_delay_seconds = query_retry_delay_seconds or 1.0
 
         # Programmatic attributes
         self.calls = 0
@@ -537,6 +564,56 @@ class BaseDataTask(BaseTask):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         return None
+
+    def retryable_execution(self, retryable_exceptions: tuple, client_object: object, *args, **kwargs) -> Any:
+        """
+        This method executes the function of a client object and retries it if it raises a retryable exception. The
+        number of attempts and delay between attempts are determined by the query_retry_max_attempts and
+        query_retry_delay_seconds attributes.
+
+        This retry logic is distinct from the larger Task retry logic because it is specific to the execution of
+        commands against a data provider. An assumption is made that data provider commands may fail due to transient
+        issues such as network issues, timeouts, or rate limiting. To that end, the retryable_exceptions argument
+        must be provided by the caller to specify which exceptions are considered retryable.
+
+        Args:
+            retryable_exceptions (tuple): A list of exceptions that are considered retryable.
+            client_object (object): The client object to execute the command on.
+            *args: The arguments to pass to the command.
+            **kwargs: The keyword arguments to pass to the command.
+        """
+
+        attempts = 0
+        while True:
+            attempts += 1
+
+            try:
+                # Some methods support args and kwargs, some only args, some only kwargs, and some neither. Therefore,
+                # we provide for all four scenarios. This kind of flexibility is required because the BaseDataTask is
+                # designed to be generic and work with any subclassed data provider.
+                if args and kwargs:
+                    return getattr(client_object, self.command)(*args, **kwargs)
+
+                elif args:
+                    return getattr(client_object, self.command)(*args)
+
+                elif kwargs:
+                    return getattr(client_object, self.command)(**kwargs)
+
+                else:
+                    return getattr(client_object, self.command)()
+
+            except retryable_exceptions as e:
+                if attempts >= self.query_retry_max_attempts:
+                    raise TaskError(self, f'MaxAttempts reached for command `{self.command}`. {e}') from e
+
+                else:
+                    from time import sleep
+                    logger.debug(f'{self.prefix}: Retrying command `{self.command}`({attempts}/{self.query_retry_max_attempts})')
+                    sleep(self.query_retry_delay_seconds)
+
+            except Exception as e:
+                raise TaskError(self, f'Error executing command `{self.command}`. {e}') from e
 
 
 class BaseFilterableTask(BaseTask):

--- a/CloudHarvestCoreTasks/tasks/base.py
+++ b/CloudHarvestCoreTasks/tasks/base.py
@@ -139,7 +139,7 @@ class BaseTask:
         self.original_template = None
         self.result = None
         self.meta = {}
-        self.errors = None
+        self.errors = []
         self.start = None
         self.end = None
 

--- a/CloudHarvestCoreTasks/tasks/base.py
+++ b/CloudHarvestCoreTasks/tasks/base.py
@@ -663,6 +663,15 @@ class BaseFilterableTask(BaseTask):
             'count'         # Return a count of the data
         )
 
+        # By default, FilterableTasks will always try to include the following keys in its records. These keys are not
+        # added to report headers; however, they should be present in the underlying JSON if they exist or can be
+        # resolved in the query chain.
+        self.add_hidden_keys = [
+            'Harvest.Active',
+            'Harvest.Dates.LastSeen',
+            'Harvest.UniqueIdentifier'
+        ]
+
         # Sets the values
         self.add_keys = self.set_accepted_filters('add_keys', add_keys, [])
         self.count = self.set_accepted_filters('count', count, False)
@@ -711,7 +720,7 @@ class BaseFilterableTask(BaseTask):
             headers = self.headers
 
         return [
-            header for header in (headers + self.add_keys)
+            header for header in (headers + self.add_keys + self.add_hidden_keys)
             if header not in self.exclude_keys
         ]
 

--- a/CloudHarvestCoreTasks/tasks/dataset.py
+++ b/CloudHarvestCoreTasks/tasks/dataset.py
@@ -101,8 +101,8 @@ class DataSetTask(BaseFilterableTask):
         """
         This method returns the keys to be added to the data. If the keys already exist, their existing values are preserved.
         """
-        if self.add_keys:
-            self.data.add_keys(keys=self.add_keys, clobber=False)
+        if self.add_keys or self.add_hidden_keys:
+            self.data.add_keys(keys=self.add_keys + self.add_hidden_keys, clobber=False)
 
         return self
 

--- a/CloudHarvestCoreTasks/tasks/harvest_update.py
+++ b/CloudHarvestCoreTasks/tasks/harvest_update.py
@@ -21,10 +21,6 @@ class HarvestUpdateTask(BaseTask):
         'Account',                      # The Platform account name or identifier
         'Region',                       # The geographic region name for the Platform
         'UniqueIdentifierKeys',         # UniqueIdentifierKeys requires at least one value, so .0 is expected
-        'Module.Author',                # The author of the Harvest module
-        'Module.Name',                  # The name of the Harvest module that collected the data
-        'Module.Url',                   # The repository where the Harvest module is stored
-        'Module.Version',               # The version of the Harvest module
         'Dates.LastSeen',               # The date indicating when the record was last collected by Harvest
         'Active',                       # A boolean indicating if the record is active
         'TaskChainId',                  # The ID of the task chain that collected the data
@@ -219,15 +215,6 @@ class HarvestUpdateTask(BaseTask):
             'ParentTaskId': self.task_chain.parent if self.task_chain else None
         }
 
-        # Convert the class / module metadata into a dictionary with Titled keys
-        # As of CloudHarvestCorePluginManager 0.1.5, class metadata is recorded when the @register_definition
-        # decorator is called, allowing the dynamic recording of metadata for each registered Harvest module and class.
-        build_components = {
-            'Module': {
-                str(k).title(): v
-                for k, v in (getattr(self, '_harvest_plugin_metadata') or {}).items()}
-        }
-
         dates = {
             'Dates': {
                 'DeactivatedOn': None,
@@ -244,7 +231,7 @@ class HarvestUpdateTask(BaseTask):
         }
 
         # Merge the components into a single metadata dictionary
-        result = WalkableDict(pstar | build_components | dates | silo)
+        result = WalkableDict(pstar | dates | silo)
 
         # Validate that all required metadata fields are present
         missing_fields = [

--- a/CloudHarvestCoreTasks/tasks/harvest_update.py
+++ b/CloudHarvestCoreTasks/tasks/harvest_update.py
@@ -525,7 +525,7 @@ class HarvestUpdateTask(BaseTask):
             bulk_end = least(bulk_start + (chunk_size - 1), len(prepared_replacements))  # 999, 1999, 2999, 3999, ... or the end of the list
 
             # Escape if we have reached the end of the list
-            if bulk_end >= len(prepared_replacements) - 1:
+            if bulk_end > len(prepared_replacements):
                 break
 
             # Perform the bulk write operation

--- a/CloudHarvestCoreTasks/tasks/harvest_update.py
+++ b/CloudHarvestCoreTasks/tasks/harvest_update.py
@@ -504,39 +504,30 @@ class HarvestUpdateTask(BaseTask):
         silo = get_silo(silo_name)
         client = silo.connect()
 
-        def least(a: int, b: int) -> int:
-            """
-            A simple function to return the least of two values.
-            a (int): The first value.
-            b (int): The second value.
-
-            Returns
-            int: The least of the two values.
-
-            """
-            return a if a < b else b
-
-        i = 0                       # Iterator for identifying chunks
-        chunk_size = 1000           # Maximum number of operations per bulk write
+        chunk_size = 1000  # Maximum number of operations per bulk write
         bulk_replace_results = {}
 
         while True:
-            bulk_start = i * chunk_size                                                  #   0, 1000, 2000, 3000, ...
-            bulk_end = least(bulk_start + (chunk_size - 1), len(prepared_replacements))  # 999, 1999, 2999, 3999, ... or the end of the list
-
-            # Escape if we have reached the end of the list
-            if bulk_end > len(prepared_replacements):
+            # If there are no more prepared replacements, exit the loop
+            if not prepared_replacements:
                 break
 
+            # The end of the chunk is either the chunk size or the end of the list
+            bulk_end = chunk_size if chunk_size <= len(prepared_replacements) else None
+
             # Perform the bulk write operation
-            write_result = client[silo.database][collection].bulk_write(requests=prepared_replacements[bulk_start:bulk_end])
+            write_result = client[silo.database][collection].bulk_write(requests=prepared_replacements[0:bulk_end])
 
             # Consolidate the write output results
-            for key, value in write_result.items():
-                bulk_replace_results[key] = bulk_replace_results.get(key) or 0 + value
+            for key, value in write_result.bulk_api_result.items():
+                if isinstance(value, int):
+                    bulk_replace_results[key] = (bulk_replace_results.get(key) or 0) + value
 
-            # Increment the iterator
-            i += 1
+                elif isinstance(value, list):
+                    bulk_replace_results[key] = (bulk_replace_results.get(key) or []) + value
+
+            # Remove the processed replacements from the list
+            del prepared_replacements[0:bulk_end]
 
         return {
             'StartTime': start_time,

--- a/CloudHarvestCoreTasks/tasks/harvest_update.py
+++ b/CloudHarvestCoreTasks/tasks/harvest_update.py
@@ -504,14 +504,44 @@ class HarvestUpdateTask(BaseTask):
         silo = get_silo(silo_name)
         client = silo.connect()
 
-        bulk_replace_results = client[silo.database][collection].bulk_write(requests=prepared_replacements)
+        def least(a: int, b: int) -> int:
+            """
+            A simple function to return the least of two values.
+            a (int): The first value.
+            b (int): The second value.
 
-        end_time = datetime.now(tz=timezone.utc)
+            Returns
+            int: The least of the two values.
+
+            """
+            return a if a < b else b
+
+        i = 0                       # Iterator for identifying chunks
+        chunk_size = 1000           # Maximum number of operations per bulk write
+        bulk_replace_results = {}
+
+        while True:
+            bulk_start = i * chunk_size                                                  #   0, 1000, 2000, 3000, ...
+            bulk_end = least(bulk_start + (chunk_size - 1), len(prepared_replacements))  # 999, 1999, 2999, 3999, ... or the end of the list
+
+            # Escape if we have reached the end of the list
+            if bulk_end >= len(prepared_replacements) - 1:
+                break
+
+            # Perform the bulk write operation
+            write_result = client[silo.database][collection].bulk_write(requests=prepared_replacements[bulk_start:bulk_end])
+
+            # Consolidate the write output results
+            for key, value in write_result.bulk_api_result.items():
+                bulk_replace_results[key] = bulk_replace_results.get(key) or 0 + value
+
+            # Increment the iterator
+            i += 1
 
         return {
             'StartTime': start_time,
             'BulkReplaceResults': bulk_replace_results,
-            'EndTime': end_time,
+            'EndTime': datetime.now(tz=timezone.utc),
         }
 
     def ensure_unique_identifier_index(self) -> 'HarvestUpdateTask':

--- a/CloudHarvestCoreTasks/tasks/harvest_update.py
+++ b/CloudHarvestCoreTasks/tasks/harvest_update.py
@@ -3,8 +3,11 @@ from CloudHarvestCoreTasks.dataset import WalkableDict
 from CloudHarvestCoreTasks.tasks.base import BaseTask
 from CloudHarvestCoreTasks.exceptions import TaskError
 
+from logging import getLogger
 from typing import List
 from pymongo import ReplaceOne
+
+logger = getLogger('harvest')
 
 
 @register_definition(name='harvest_update', category='task')
@@ -483,8 +486,7 @@ class HarvestUpdateTask(BaseTask):
 
         return self
 
-    @staticmethod
-    def bulk_replace(silo_name: str, collection: str, prepared_replacements: List[ReplaceOne]) -> dict:
+    def bulk_replace(self, silo_name: str, collection: str, prepared_replacements: List[ReplaceOne]) -> dict:
         """
         This method performs a bulk Replace operation on the specified silo.
 
@@ -516,7 +518,25 @@ class HarvestUpdateTask(BaseTask):
             bulk_end = chunk_size if chunk_size <= len(prepared_replacements) else None
 
             # Perform the bulk write operation
-            write_result = client[silo.database][collection].bulk_write(requests=prepared_replacements[0:bulk_end])
+            write_attempts = 0
+
+            while True:
+                try:
+                    # Write records to the backend database
+                    write_result = client[silo.database][collection].bulk_write(requests=prepared_replacements[0:bulk_end])
+                    break
+
+                except Exception as e:
+                    # If we exceed the maximum attempts, raise the error
+                    if write_attempts > 10:
+                        raise e
+
+                    # Allow retry when writing data to the backend database
+                    write_attempts += 1
+                    logger.debug(f'{self.prefix}: error recording records to backend: {e}')
+
+                    from time import sleep
+                    sleep(.25 * write_attempts)
 
             # Consolidate the write output results
             for key, value in write_result.bulk_api_result.items():

--- a/CloudHarvestCoreTasks/tasks/harvest_update.py
+++ b/CloudHarvestCoreTasks/tasks/harvest_update.py
@@ -532,7 +532,7 @@ class HarvestUpdateTask(BaseTask):
             write_result = client[silo.database][collection].bulk_write(requests=prepared_replacements[bulk_start:bulk_end])
 
             # Consolidate the write output results
-            for key, value in write_result.bulk_api_result.items():
+            for key, value in write_result.items():
                 bulk_replace_results[key] = bulk_replace_results.get(key) or 0 + value
 
             # Increment the iterator

--- a/CloudHarvestCoreTasks/tasks/mongo.py
+++ b/CloudHarvestCoreTasks/tasks/mongo.py
@@ -284,7 +284,7 @@ class MongoTask(BaseDataTask, BaseFilterableTask):
         if sort_keys:
             result = {}
 
-            for sort in self.sort:
+            for sort in sort_keys:
                 if ':' in sort:
                     field, direction = sort.split(':')
 
@@ -300,7 +300,7 @@ class MongoTask(BaseDataTask, BaseFilterableTask):
                     result[sort] = 1
 
             return {
-                '$sort': result
+                '$sort': result | { '_id': 1 }  # Tie-breaker to ensure consistent ordering
             }
 
         return None

--- a/CloudHarvestCoreTasks/tasks/mongo.py
+++ b/CloudHarvestCoreTasks/tasks/mongo.py
@@ -279,7 +279,9 @@ class MongoTask(BaseDataTask, BaseFilterableTask):
         }
 
     def _filter_sort(self) -> dict or None:
-        if self.sort:
+        sort_keys = self.sort or self.filter_keys()
+
+        if sort_keys:
             result = {}
 
             for sort in self.sort:

--- a/CloudHarvestCoreTasks/tasks/mongo.py
+++ b/CloudHarvestCoreTasks/tasks/mongo.py
@@ -79,21 +79,30 @@ class MongoTask(BaseDataTask, BaseFilterableTask):
     def _filter_add_keys(self, *args, **kwargs) -> None:
         """
         This method identifies the first $projection in the pipeline and adds the desired keys to the projection.
-        Where the key contains the period character, the period is removed from the key.
+        Where the key contains the period character, the period is removed from the key. If no projection is present
+        a new one will be added.
 
         Returns
             None: This method does not return anything. It modifies the pipeline in place.
         """
 
-        if self.add_keys:
+        if self.add_keys or self.add_hidden_keys:
             # Find the first projection of the pipeline
             for stage in self.arguments.get('pipeline') or []:
                 if list(stage.keys())[0] == '$project':
                     # Add the keys to the projection
-                    for key in self.add_keys:
+                    for key in self.add_keys + self.add_hidden_keys:
                         stage['$project'][key] = 1
 
                     break
+
+            # else:
+            #     new_project_stage = {'$project': {}}
+            #
+            #     for key in self.add_keys + self.add_hidden_keys:
+            #         new_project_stage['$project'][key] = 1
+            #
+            #     self.arguments['pipeline'].append(new_project_stage)
 
         return None
 

--- a/CloudHarvestCoreTasks/tasks/mongo.py
+++ b/CloudHarvestCoreTasks/tasks/mongo.py
@@ -3,6 +3,10 @@ from CloudHarvestCoreTasks.tasks.base import BaseDataTask, BaseFilterableTask
 from CloudHarvestCoreTasks.exceptions import TaskError
 
 from pymongo import MongoClient
+from pymongo.errors import *
+
+from logging import getLogger
+logger = getLogger('harvest')
 
 
 @register_definition(name='mongo', category='task')
@@ -331,10 +335,22 @@ class MongoTask(BaseDataTask, BaseFilterableTask):
             # Expose database-level commands
             database_object = client[self.silo.database]
 
-        # Execute the command on the database or collection
-        self.calls += 1
+        # Define the exceptions that should trigger a retry
+        retryable_exceptions = (
+            AutoReconnect,
+            ExecutionTimeout,
+            NetworkTimeout,
+            ServerSelectionTimeoutError,
+            WTimeoutError,
+            WaitQueueTimeoutError
+        )
 
-        result = getattr(database_object, self.command)(**self.arguments)
+        # Execute the command with retry logic
+        result = self.retryable_execution(
+            retryable_exceptions=retryable_exceptions,
+            client_object=database_object,
+            **self.arguments
+        )
 
         # Convert the result to a list if it is a generator or cursor
         from types import GeneratorType

--- a/CloudHarvestCoreTasks/tasks/redis.py
+++ b/CloudHarvestCoreTasks/tasks/redis.py
@@ -1,7 +1,10 @@
 from CloudHarvestCorePluginManager import register_definition
+from urllib3.exceptions import MaxRetryError
+
 from CloudHarvestCoreTasks.tasks.base import BaseDataTask
 
 from logging import getLogger
+from redis.exceptions import *
 from typing import Any, Literal
 
 logger = getLogger('harvest')
@@ -77,8 +80,28 @@ class RedisTask(BaseDataTask):
             # Serialize the data before writing to Redis
             self.arguments[self.serializer_key] = dumps(self.arguments.get(self.serializer_key) or {}, default=str)
 
+        # Define retryable exceptions
+        retryable_exceptions = (
+            BusyLoadingError,
+            ChildDeadlockedError,
+            ClusterCrossSlotError,
+            ClusterDownError,
+            ConnectionError,
+            ExecAbortError,
+            LockError,
+            MasterDownError,
+            MaxRetryError,
+            OutOfMemoryError,
+            TimeoutError,
+            TryAgainError
+        )
+
         # Execute the command using the RedisClient
-        result = getattr(client, self.command)(**self.arguments)
+        result = self.retryable_execution(
+            retryable_exceptions=retryable_exceptions,
+            client_object=client,
+            **self.arguments
+        )
 
         if self.command == 'scan':
             # The scan command returns a tuple of (cursor, data), so we need to extract the data

--- a/CloudHarvestCoreTasks/templating.py
+++ b/CloudHarvestCoreTasks/templating.py
@@ -142,6 +142,23 @@ def parse_datetime(reference_date: (str or datetime) = None, result_tz_aware: bo
         return None
 
 # FILTERS
+def filter_datetime_ago(year: int = None, month: int = None, day: int = None, hour: int = None, minute: int = None, second: int = None, result_as_datatime: bool = False) -> datetime:
+    """
+    This function calculates a datetime in the past from the current datetime.
+    Args:
+    year (int, optional): The number of years to subtract. Defaults to None.
+    month (int, optional): The number of months to subtract. Defaults to None.
+    day (int, optional): The number of days to subtract. Defaults to None.
+    hour (int, optional): The number of hours to subtract. Defaults to None.
+    minute (int, optional): The number of minutes to subtract. Defaults to None.
+    second (int, optional): The number of seconds to subtract. Defaults to None.
+    result_as_datatime (bool, optional): Whether to return the result as a datetime object. When False, the result is returned as a string. Defaults to False.
+
+    Returns
+    datetime or str: The calculated datetime.
+
+    """
+
 def filter_datetime_since(
         reference_date: (str or datetime) = None,
         result_as_string: bool = False,

--- a/CloudHarvestCoreTasks/templating.py
+++ b/CloudHarvestCoreTasks/templating.py
@@ -142,22 +142,30 @@ def parse_datetime(reference_date: (str or datetime) = None, result_tz_aware: bo
         return None
 
 # FILTERS
-def filter_datetime_ago(year: int = None, month: int = None, day: int = None, hour: int = None, minute: int = None, second: int = None, result_as_datatime: bool = False) -> datetime:
+def filter_datetime_ago(days: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0, result_as_datatime: bool = False) -> datetime or str:
     """
     This function calculates a datetime in the past from the current datetime.
     Args:
-    year (int, optional): The number of years to subtract. Defaults to None.
-    month (int, optional): The number of months to subtract. Defaults to None.
-    day (int, optional): The number of days to subtract. Defaults to None.
-    hour (int, optional): The number of hours to subtract. Defaults to None.
-    minute (int, optional): The number of minutes to subtract. Defaults to None.
-    second (int, optional): The number of seconds to subtract. Defaults to None.
+    days (int, optional): The number of days to subtract. Defaults to 0.
+    hours (int, optional): The number of hours to subtract. Defaults to 0.
+    minutes (int, optional): The number of minutes to subtract. Defaults to 0.
+    seconds (int, optional): The number of seconds to subtract. Defaults to 0.
     result_as_datatime (bool, optional): Whether to return the result as a datetime object. When False, the result is returned as a string. Defaults to False.
 
     Returns
     datetime or str: The calculated datetime.
-
     """
+
+    from datetime import datetime, timedelta, timezone
+    
+    now = datetime.now(tz=timezone.utc)
+    result = now - timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+    
+    if result_as_datatime:
+        return result
+    else:
+        return result.isoformat()
+    
 
 def filter_datetime_since(
         reference_date: (str or datetime) = None,

--- a/CloudHarvestCoreTasks/templating.py
+++ b/CloudHarvestCoreTasks/templating.py
@@ -2,7 +2,7 @@
 This module contains functions for rendering templates using the Jinja2 templating engine.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from logging import getLogger
@@ -110,7 +110,6 @@ def parse_datetime(reference_date: (str or datetime) = None, result_tz_aware: bo
     """
 
     from dateutil.parser import parse
-    from datetime import timezone
 
     try:
         # If reference_date is a string, parse it into a datetime object
@@ -142,37 +141,24 @@ def parse_datetime(reference_date: (str or datetime) = None, result_tz_aware: bo
         return None
 
 # FILTERS
-def filter_datetime_ago(days: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0, result_as_datatime: bool = False) -> datetime or str:
+# ======================================================================================================================
+
+def filter_datetime_ago(**timedelta_kwargs) -> datetime:
     """
     This function calculates a datetime in the past from the current datetime.
-    Args:
-    days (int, optional): The number of days to subtract. Defaults to 0.
-    hours (int, optional): The number of hours to subtract. Defaults to 0.
-    minutes (int, optional): The number of minutes to subtract. Defaults to 0.
-    seconds (int, optional): The number of seconds to subtract. Defaults to 0.
-    result_as_datatime (bool, optional): Whether to return the result as a datetime object. When False, the result is returned as a string. Defaults to False.
+    Args
+        **timedelta_kwargs: Arguments to pass to the timedelta function: days, hours, minutes, seconds, etc.
 
     Returns
     datetime or str: The calculated datetime.
     """
 
-    from datetime import datetime, timedelta, timezone
-    
     now = datetime.now(tz=timezone.utc)
-    result = now - timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+    result = now - timedelta(**timedelta_kwargs)
     
-    if result_as_datatime:
-        return result
-    else:
-        return result.isoformat()
+    return result
     
-
-def filter_datetime_since(
-        reference_date: (str or datetime) = None,
-        result_as_string: bool = False,
-        **timedelta_kwargs
-
-) -> (str or datetime):
+def filter_datetime_since(reference_date: (str or datetime) = None, result_as_string: bool = False, **timedelta_kwargs) -> datetime:
     """
     This function calculates a datetime in the past from a reference date.
 
@@ -185,8 +171,6 @@ def filter_datetime_since(
         str or datetime: The calculated datetime.
     """
 
-    from datetime import timedelta
-
     start_date = parse_datetime(reference_date)
 
     result = start_date - timedelta(**timedelta_kwargs)
@@ -198,58 +182,34 @@ def filter_datetime_since(
         return result
 
 
-def filter_datetime_until(
-        reference_date: (str or datetime) = None,
-        result_as_string: bool = False,
-        **timedelta_kwargs
-
-) -> (str or datetime):
+def filter_datetime_until(reference_date: str or datetime = None, **timedelta_kwargs) -> datetime:
     """
     This function calculates a datetime in the future from a reference date.
 
     Args:
         reference_date (str or datetime, optional): The reference date. Defaults to None.
-        result_as_string (bool, optional): Whether to return the result as a string. Defaults to False.
         **timedelta_kwargs: Arguments to pass to the timedelta function.
 
     Returns:
         str or datetime: The calculated datetime.
     """
 
-    from datetime import timedelta
-
     start_date = parse_datetime(reference_date)
 
     result = start_date + timedelta(**timedelta_kwargs)
 
-    if result_as_string:
-        return result.isoformat()
-
-    else:
-        return result
+    return result
 
 
-def filter_datetime_now(as_epoc: bool = False, result_tz_aware: bool = True) -> datetime or float:
+def filter_datetime_now() -> datetime:
     """
-    Returns the current datetime.
+    Returns the current UTC datetime.
 
-    This function returns the current datetime. If `as_epoc` is set to True, it returns the current datetime as a Unix timestamp.
-    If `result_tz_aware` is set to True, the returned datetime object is timezone aware (set to UTC). If False, the datetime object is naive.
-
-    Args:
-        as_epoc (bool, optional): If True, returns the current datetime as a Unix timestamp. Defaults to False.
-        result_tz_aware (bool, optional): If True, the returned datetime object is timezone aware (set to UTC). If False, the datetime object is naive. Defaults to True.
+    This function returns the current datetime.
 
     Returns:
-        datetime or float: The current datetime. If `as_epoc` is True, this will be a Unix timestamp. Otherwise, it will be a datetime object.
+        datetime: The current datetime.
     """
-    from datetime import datetime, timezone
 
     # Get the current datetime
-    now = datetime.now(tz=timezone.utc) if result_tz_aware else datetime.now()
-
-    # If as_epoc is True, return the current datetime as a Unix timestamp
-    if as_epoc:
-        return now.timestamp()
-    else:
-        return now
+    return datetime.now(tz=timezone.utc)

--- a/docs/tasks/base_data.md
+++ b/docs/tasks/base_data.md
@@ -13,11 +13,13 @@ The `BaseDataTask` class should not be used directly. Instead, it should be subc
 
 ### Directives
 
-| Directive   | Required | Default | Description                                                 |
-|-------------|----------|---------|-------------------------------------------------------------|
-| `command`   | Yes      | None    | The command to run on the data provider.                    |
-| `arguments` | No       | None    | Arguments to pass to the command.                           |
-| `silo`      | No       | None    | The name of the silo to use for the task. Defaults to None. |
+| Directive                   | Required | Default | Description                                                 |
+|-----------------------------|----------|---------|-------------------------------------------------------------|
+| `command`                   | Yes      | None    | The command to run on the data provider.                    |
+| `arguments`                 | No       | None    | Arguments to pass to the command.                           |
+| `silo`                      | No       | None    | The name of the silo to use for the task. Defaults to None. |
+| `query_retry_max_attempts`  | No       | `3`     | The maximum number of attempts to retry a query.            |
+| `query_retry_delay_seconds` | No       | `1.0`   | The number of seconds to wait before retrying a query.      |
 
 ## Example
 _See [MongoTask](./mongo.md) for an example of a subclass of the BaseDataTask class._

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -291,12 +291,21 @@ class TestDataSetTask(BaseTestCase):
         harvest_dataset_task_template = {
             "name": "test_chain",
             "description": "This is a test chain.",
+            "headers": [
+                "name",
+                "age",
+                "date",
+                "tags",
+                "tags_dict",
+                "age_copy"
+            ],
             "tasks": [
                 {
                     "dataset": {
                         "name": "test dataset task",
                         "description": "This is a test record set",
                         "data": "var.test_dataset",
+                        "filters": ".*",
                         "stages": [
                             {
                                 "convert_list_of_dict_to_dict": {
@@ -336,9 +345,9 @@ class TestDataSetTask(BaseTestCase):
             }
         ]
 
-        from chains.base import BaseTaskChain
+        from chains.report import ReportTaskChain
         self.test_data = test_data
-        self.chain = BaseTaskChain(template=harvest_dataset_task_template)
+        self.chain = ReportTaskChain(template=harvest_dataset_task_template)
         self.chain.variables["test_dataset"] = self.test_data
 
     def test_init(self):
@@ -444,10 +453,15 @@ class TestMongoTask(BaseTestCase):
 
         assert len(list(self.collection.find())) == 0
 
-    def test_method_find(self):
+    def test_method_aggregate(self):
         task_chain_configuration = {
             'report': {
                 'name': 'test_chain',
+                'headers': [
+                    'name.family',
+                    'name.given',
+                    'address.city'
+                ],
                 'tasks': [
                     {
                         'mongo': {
@@ -455,9 +469,11 @@ class TestMongoTask(BaseTestCase):
                             'silo': 'test_silo',
                             'collection': 'users',
                             'result_as': 'mongo_result',
-                            'command': 'find',
+                            'command': 'aggregate',
+                            'filters': '.*',
                             'arguments': {
-                                'filter': {}
+                                'pipeline': [
+                                ]
                             },
 
                         }
@@ -469,7 +485,7 @@ class TestMongoTask(BaseTestCase):
         task_chain = task_chain_from_dict(template=task_chain_configuration)
         task_chain.run()
 
-        self.assertFalse(task_chain.errors)
+        self.assertFalse(task_chain.errors and task_chain[0].errors)
         self.assertEqual(len(task_chain.result['data']), 10)
 
     # def test_method_subcommand(self):

--- a/tests/test_templating_filters.py
+++ b/tests/test_templating_filters.py
@@ -21,7 +21,7 @@ class TestFilters(unittest.TestCase):
     def test_filter_datetime_ago(self):
         from datetime import timedelta
         expected_date = datetime.now(tz=timezone.utc) - timedelta(days=1)
-        self.assertEqual(templating.filter_datetime_ago(days=1, result_as_datatime=True).day, expected_date.day)
+        self.assertEqual(templating.filter_datetime_ago(days=1).day, expected_date.day)
 
     def test_filter_datetime_since(self):
         reference_date = datetime(2022, 1, 1, tzinfo=timezone.utc)
@@ -35,7 +35,6 @@ class TestFilters(unittest.TestCase):
         expected_date = datetime(2022, 1, 2, tzinfo=timezone.utc)
         self.assertEqual(templating.filter_datetime_until(reference_date, days=1), expected_date)
         self.assertEqual(templating.filter_datetime_until(reference_date.isoformat(), days=1), expected_date)
-        self.assertEqual(templating.filter_datetime_until(reference_date, result_as_string=True, days=1), expected_date.isoformat())
 
     def test_filter_datetime_now(self):
         from CloudHarvestCoreTasks.templating import filter_datetime_now
@@ -43,13 +42,6 @@ class TestFilters(unittest.TestCase):
         # Test that the function returns a timezone aware datetime object by default
         self.assertIsInstance(filter_datetime_now(), datetime)
         self.assertIsNotNone(filter_datetime_now().tzinfo)
-
-        # Test that the function returns a naive datetime object if result_tz_aware is False
-        self.assertIsInstance(filter_datetime_now(result_tz_aware=False), datetime)
-        self.assertIsNone(filter_datetime_now(result_tz_aware=False).tzinfo)
-
-        # Test that the function returns a Unix timestamp if as_epoc is True
-        self.assertIsInstance(filter_datetime_now(as_epoc=True), float)
 
 
 if __name__ == '__main__':

--- a/tests/test_templating_filters.py
+++ b/tests/test_templating_filters.py
@@ -18,6 +18,11 @@ class TestFilters(unittest.TestCase):
         self.assertEqual(templating.parse_datetime(date_obj), date_obj)
         self.assertIsNone(templating.parse_datetime('invalid date'))
 
+    def test_filter_datetime_ago(self):
+        from datetime import timedelta
+        expected_date = datetime.now(tz=timezone.utc) - timedelta(days=1)
+        self.assertEqual(templating.filter_datetime_ago(days=1, result_as_datatime=True).day, expected_date.day)
+
     def test_filter_datetime_since(self):
         reference_date = datetime(2022, 1, 1, tzinfo=timezone.utc)
         expected_date = datetime(2021, 12, 31, tzinfo=timezone.utc)


### PR DESCRIPTION
## 0.8.2
- [#36](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/36): `MongoTask` and `RedisTask` will now retry database operations using a new method provided in `BaseDataTask`.
- [#37](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/37): Log messages now include the calling filename, line number, and task name. 
- [#38](https://github.com/Cloud-Harvest/CloudHarvestCoreTasks/issues/38): Address `'NoneType' object has no attriute 'append'` in the `TaskError` exception class.
 - `BaseTask` now offers the `prefix` property used for log entries.
- `HarvestUpdateTask.bulk_replace()`
  - now chunks large replacements to prevent overwhelming the database.
  - now retries writes as sometimes the backend database is too busy to complete the request at that time.
- Added `filter_datetime_ago()` jinja2 filter.
- `BaseFilterableTask` now includes `add_hidden_fields` which returns certain key fields back to the client.